### PR TITLE
chihiro: fix hardware field

### DIFF
--- a/Batocera/x86 64bit (additional)/system/configs/emulationstation/es_systems_chihiro.cfg
+++ b/Batocera/x86 64bit (additional)/system/configs/emulationstation/es_systems_chihiro.cfg
@@ -6,7 +6,7 @@
         <name>chihiro</name>
         <manufacturer>Sega</manufacturer>
         <release>2002</release>
-        <hardware>chihiro, arcade</hardware>
+        <hardware>arcade</hardware>
         <path>/userdata/roms/chihiro</path>
         <extension>.iso .squashfs .xiso</extension>
         <command>emulatorlauncher %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM% -gameinfoxml %GAMEINFOXML% -systemname %SYSTEMNAME%</command>


### PR DESCRIPTION
only use "arcade", or we can't regroup it with other arcade system when sorting by hardware